### PR TITLE
Avoid python 3 complexity bug

### DIFF
--- a/precog/install.py
+++ b/precog/install.py
@@ -27,7 +27,7 @@ import precog
 # The default for all the other *_STRICT values
 STRICT = os.getenv('STRICT', True)
 
-FLAKE8_COMPLEXITY = os.getenv('FLAKE8_COMPLEXITY')
+FLAKE8_COMPLEXITY = os.getenv('FLAKE8_COMPLEXITY', -1)
 FLAKE8_STRICT = os.getenv('FLAKE8_STRICT', STRICT)
 FLAKE8_IGNORE = os.getenv('FLAKE8_IGNORE')
 FLAKE8_LAZY = os.getenv('FLAKE8_LAZY', False)


### PR DESCRIPTION
In python 3, running the hook causes an error:

```
File "/home/tom/.virtualenvs/happi-frontend/lib/python3.4/site-packages/flake8/hooks.py", line 48, in git_hook
    if complexity > -1:
TypeError: unorderable types: NoneType() > int()
```

Work around this by providing an explicit default in our hook, so there will always be a number to compare to, not `None`.
