### PR TITLE
Use our own wrapper around getenv

### DIFF
--- a/precog/__init__.py
+++ b/precog/__init__.py
@@ -168,3 +168,33 @@ def hook(**kwargs):
         isort_git_hook(**isort_kwargs) or
         flake8_git_hook(**flake8_kwargs) or
         eslint(**eslint_kwargs))
+
+
+# A dict mapping an option to a pair of (type, fallback). The fallback
+# will be used if the value cannot be converted to the specified type.
+CUSTOM_TYPES = {
+    # It turns out that `None` is not a valid default for the
+    # complexity as of python3.
+    'FLAKE8_COMPLEXITY': (int, -1),
+}
+
+
+def getenv(key, default=None):
+    """A wrapper around os.getenv so we can tweak things to be the right
+    type.
+
+    """
+    value = os.getenv(key, default)
+
+    custom_type, fallback = CUSTOM_TYPES.get(key, (None, None))
+
+    if custom_type:
+        try:
+            return custom_type(value)
+        except ValueError:
+            print('Invalid value for {}. Ignoring.'.format(key))
+            return fallback
+        except TypeError:
+            # Then it isn't currently set, don't bother printing a
+            # message, just use the fallback.
+            return fallback

--- a/precog/install.py
+++ b/precog/install.py
@@ -20,21 +20,20 @@ from flake8 import hooks
 
 
 git_hook_file = '''#!/usr/bin/env python
-import os
 import precog
 
 
 # The default for all the other *_STRICT values
-STRICT = os.getenv('STRICT', True)
+STRICT = precog.getenv('STRICT', True)
 
-FLAKE8_COMPLEXITY = os.getenv('FLAKE8_COMPLEXITY', -1)
-FLAKE8_STRICT = os.getenv('FLAKE8_STRICT', STRICT)
-FLAKE8_IGNORE = os.getenv('FLAKE8_IGNORE')
-FLAKE8_LAZY = os.getenv('FLAKE8_LAZY', False)
-ISORT_STRICT = os.getenv('ISORT_STRICT', STRICT)
-ISORT_FORCE = os.getenv('ISORT_FORCE', False)  # should isort rewrite your commit to fix it
-ESLINT_STRICT = os.getenv('ESLINT_STRICT', STRICT)
-ESLINT_PATH = os.getenv('ESLINT_PATH')  # path to the eslint executable
+FLAKE8_COMPLEXITY = precog.getenv('FLAKE8_COMPLEXITY')
+FLAKE8_STRICT = precog.getenv('FLAKE8_STRICT', STRICT)
+FLAKE8_IGNORE = precog.getenv('FLAKE8_IGNORE')
+FLAKE8_LAZY = precog.getenv('FLAKE8_LAZY', False)
+ISORT_STRICT = precog.getenv('ISORT_STRICT', STRICT)
+ISORT_FORCE = precog.getenv('ISORT_FORCE', False)  # should isort rewrite your commit to fix it
+ESLINT_STRICT = precog.getenv('ESLINT_STRICT', STRICT)
+ESLINT_PATH = precog.getenv('ESLINT_PATH')  # path to the eslint executable
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So that if we have to tweak some defaults, we don't need to change pre-commit files.
