### PR TITLE
Change option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ To skip just isort:
 ISORT_STRICT="" git commit -m "wip - todo: fix imports"
 ```
 
+If you want to specify a change to the built-in defaults permanently,
+you can add to to the `defaults` dict in the pre-commit file. If you
+specify:
+
+```python
+defaults = {
+    `isort_strict`: False
+}
+```
+
+then run `git commit -m "message here"`, this will not restrict if
+isort fails. But you can then override this from the command line if
+you then run `ISORT_STRICT=1 git commit -m "message here"`.
+
 The `ISORT_FORCE` option
 ========================
 
@@ -63,3 +77,24 @@ makes no attempt to install eslint, but will try to find it at
 is installed globally. You can set the `ESLINT_PATH` environment
 variable if this doesn't find it - if so you may want to set it as a
 default in your pre-commit file.
+
+List of recognised options
+==========================
+
+- `STRICT`, `bool` - the default for all the other `*_STRICT` values
+
+- `FLAKE8_COMPLEXITY`, `int` - the McCabe complexity value to pass to flake8.
+
+- `FLAKE8_STRICT`, `bool` - should a flake8 error abort the commit?
+
+- `FLAKE8_IGNORE`, `str` - comma separated list of flake8-checks to ignore.
+
+- `FLAKE8_LAZY`, `bool` - allows for the instances where you don’t add the files to the index.
+
+- `ISORT_STRICT`, `bool` - should an isort error abort the commit?
+
+- `ISORT_FORCE`, `bool` - should isort fixup your commit for you?
+
+- `ESLINT_STRICT`, `bool` - should an eslint error abort the commit?
+
+- `ESLINT_PATH`, `str` - path to the eslint executable.

--- a/precog/install.py
+++ b/precog/install.py
@@ -20,33 +20,12 @@ from flake8 import hooks
 
 
 git_hook_file = '''#!/usr/bin/env python
-import os
 import precog
 
-
-# The default for all the other *_STRICT values
-STRICT = os.getenv('STRICT', True)
-
-FLAKE8_COMPLEXITY = os.getenv('FLAKE8_COMPLEXITY', -1)
-FLAKE8_STRICT = os.getenv('FLAKE8_STRICT', STRICT)
-FLAKE8_IGNORE = os.getenv('FLAKE8_IGNORE')
-FLAKE8_LAZY = os.getenv('FLAKE8_LAZY', False)
-ISORT_STRICT = os.getenv('ISORT_STRICT', STRICT)
-ISORT_FORCE = os.getenv('ISORT_FORCE', False)  # should isort rewrite your commit to fix it
-ESLINT_STRICT = os.getenv('ESLINT_STRICT', STRICT)
-ESLINT_PATH = os.getenv('ESLINT_PATH')  # path to the eslint executable
-
+defaults = dict()
 
 if __name__ == '__main__':
-    precog.hook(
-        flake8_complexity=FLAKE8_COMPLEXITY,
-        flake8_strict=FLAKE8_STRICT,
-        flake8_ignore=FLAKE8_IGNORE,
-        flake8_lazy=FLAKE8_LAZY,
-        isort_strict=ISORT_STRICT,
-        isort_force=ISORT_FORCE,
-        eslint_strict=ESLINT_STRICT,
-        eslint_path=ESLINT_PATH)
+    precog.hook(**defaults)
 '''
 
 

--- a/precog/options.py
+++ b/precog/options.py
@@ -1,0 +1,112 @@
+from __future__ import print_function, unicode_literals
+
+import sys
+
+
+def kwargs_remove_prefix(kwargs, prefix):
+    return {k[len(prefix):]: v for k, v in kwargs.items() if k.startswith(prefix)}
+
+
+def keys_to_lower(d):
+    return {k.lower(): v for k, v in d.items()}
+
+
+class Options(object):
+
+    _DEFAULT = object()
+    # So we can declare the kwargs in DEFAULTS for completeness, but
+    # it won't do anything.
+    _SKIP = object()
+
+    # Indicates that if an option is not given, it should borrow its
+    # value from the specified option.
+    class Borrow(object):
+        def __init__(self, borrow_from):
+            self.borrow_from = borrow_from
+
+    DEFAULTS = {
+        'strict': True,
+
+        'flake8_complexity': -1,
+        'flake8_strict': Borrow('strict'),
+        'flake8_ignore': _SKIP,
+        'flake8_lazy': False,
+
+        'isort_strict': Borrow('strict'),
+        'isort_force': False,
+
+        'eslint_strict': Borrow('strict'),
+        'eslint_path': _SKIP,
+    }
+
+    # A dict mapping an option to a pair of (type, fallback). The
+    # fallback will be used if the value cannot be converted to the
+    # specified type.
+    CUSTOM_TYPES = {
+        # It turns out that `None` is not a valid default for the
+        # complexity as of python3.
+        'flake8_complexity': (int, -1),
+    }
+
+    def __init__(self, environment_vars, precommit_defaults):
+        # Because passing `flake8_strict` or `FLAKE8_STRICT` are both
+        # valid, we convert all options to lower case.
+        self.environment_vars = keys_to_lower(environment_vars)
+        self.precommit_defaults = keys_to_lower(precommit_defaults)
+
+    def get(self, key, default=_DEFAULT):
+        """Get a value, working our way through the three different possible
+        places.
+
+        """
+        key = key.lower()
+        val = self.environment_vars.get(key, default)
+        if val is not self._DEFAULT:
+            return val
+        val = self.precommit_defaults.get(key, default)
+        if val is not self._DEFAULT:
+            return val
+        return self.DEFAULTS[key]
+
+    def type_convert(self, key, value):
+        """Some keys are more picky about their types. Convert any that are
+        the wrong type.
+
+        """
+        custom_type, fallback = self.CUSTOM_TYPES.get(key, (None, None))
+
+        if custom_type:
+            try:
+                return custom_type(value)
+            except ValueError:
+                print('Invalid value for {}. Ignoring.'.format(key), file=sys.stderr)
+                return fallback
+            except TypeError:
+                # Then it isn't currently set, don't bother printing a
+                # message, just use the fallback.
+                return fallback
+        return value
+
+    def get_kwargs(self, prefix):
+        """Get the kwargs, gathering appropriate defaults, and with correct
+        types.
+
+        """
+        kwargs = {}
+        for key in [k for k in self.DEFAULTS if k.startswith(prefix)]:
+            value = self.get(key)
+            if isinstance(value, self.Borrow):
+                kwargs[key] = self.get(value.borrow_from)
+            elif value is self._SKIP:
+                continue
+            else:
+                kwargs[key] = value
+
+        # Now apply the type conversions
+        typed_kwargs = {}
+        for k, v in kwargs.items():
+            typed_kwargs[k] = self.type_convert(k, v)
+
+        # Finally remove the prefix. Do this last so we have the full
+        # name during processing.
+        return kwargs_remove_prefix(typed_kwargs, prefix)


### PR DESCRIPTION
This makes the option handling a lot more solid, and removes lots of stuff from the pre-commit file.

For that reason, this is kinda horrible for backwards-compatibility. To change from the old way to the new way, will want to replace any occurrences of (eg)

``` python
ISORT_FORCE = os.getenv('ISORT_FORCE', False)
```

with

``` python
defaults = dict(
    ...
    flake8_ignore=False,
    ...
)
```
